### PR TITLE
Speed up checking are all elements 0 or 1

### DIFF
--- a/src/detx.jl
+++ b/src/detx.jl
@@ -60,7 +60,7 @@ function detx!(A::AbstractArray{T,2}) where T
     end
 
     col = A[:,1]  # first column
-    if all(col .== 0)
+    if iszero(col)
         return 0
     end
 

--- a/src/invx.jl
+++ b/src/invx.jl
@@ -19,7 +19,7 @@ function invx(A::AbstractArray{T,2}) where T
     X = rrefx(X)
 
     d = [X[i,i] for i=1:r]
-    if all(d.==1)
+    if isone(d)
         return X[:,r+1:end]
     end
     @error "Matrix is not intertible"

--- a/src/nullspacex.jl
+++ b/src/nullspacex.jl
@@ -11,11 +11,10 @@ function nullspacex(A::Matrix{T}) where T
     # in each row, find first 1
     for i=1:r
         row = B[i,:]
-        if all(row .== 0)
-            continue
-        end
         k = findfirst(row .!= 0)
-        append!(leads,k)
+        if k !== nothing
+            append!(leads,k)
+        end
     end
 
     frees = setdiff(collect(1:c), leads)

--- a/src/rankx.jl
+++ b/src/rankx.jl
@@ -17,7 +17,7 @@ function rankx(A::AbstractArray{T,2})::Int where T
 
     count = 0
     for i=1:r
-        if any(AA[i,:] .!= 0)
+        if !iszero(AA[i,:])
             count += 1
         end
     end
@@ -36,11 +36,10 @@ function nullspacex(A::AbstractArray{T,2}) where T
     # in each row, find first 1
     for i=1:r
         row = B[i,:]
-        if all(row .== 0)
-            continue
-        end
         k = findfirst(row .!= 0)
-        append!(leads,k)
+        if k !== nothing
+            append!(leads,k)
+        end
     end
 
     frees = setdiff(collect(1:c), leads)

--- a/src/rrefx.jl
+++ b/src/rrefx.jl
@@ -33,10 +33,10 @@ function rrefx!(A::AbstractArray{T,2}) where T
     for j=1:nc
         # see if column j's first one is at level r or below
         col = A[r:end,j]
-        if all(col .== 0)
+        k = findfirst(col .!= 0)
+        if k === nothing
             continue
         end
-        k = findfirst(col .!= 0)
         row_swap!(A,r,k+r-1)
         _pivot!(A,r,j)
         r += 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ H = hilbert(12)
 
 A = ones(Int,3,5)
 N = nullspacex(A)
-@test all(0 .== A*N)
+@test iszero(A*N)
 
 
 using SimplePolynomials


### PR DESCRIPTION
Example comparision:

a) now
```julia
julia> A = rand(Int, 20, 20)

julia> @btime rankx(A)
  47.742 ms (354507 allocations: 10.45 MiB)
20
```

b) before
```
julia> @btime rankx(A)
  49.167 ms (354532 allocations: 10.45 MiB)
20
```

A bit more efficient, as it doesn't search for zeros twice. `all(collection .== 0)` is equivalent to `iszero(collection)`, `all(collection .== 1)` to `isone(collection)`. Supposedly iszero / isone is more efficient than .== 0 / 1.