### PR TITLE
Use AbstractMatrix in all methods

### DIFF
--- a/src/char_poly.jl
+++ b/src/char_poly.jl
@@ -1,6 +1,6 @@
 export char_poly
 
-function char_poly(A::Matrix{T}) where T<:TypeX
+function char_poly(A::AbstractMatrix{T}) where T<:TypeX
     r,c = size(A)
     @assert r==c "Matrix must be square"
 

--- a/src/cofactor_det.jl
+++ b/src/cofactor_det.jl
@@ -1,13 +1,13 @@
 export cofactor_det
 
 """
-`cofactor(A::Matrix{T})` computes the determinant of `A` using
+`cofactor(A::AbstractMatrix{T})` computes the determinant of `A` using
 cofactor expansion (which can be slow).
 The return type of this method is a number of type `T`.
 The entires in `A` can be polynomials and that won't work with
 Julia's `det`.
 """
-function cofactor_det(A::Matrix{T}) where T
+function cofactor_det(A::AbstractMatrix{T}) where T
     r,c = size(A)
     @assert r==c "Matrix must be square"
     @assert r>0 "Matrix cannot be 0-by-0"

--- a/src/detx.jl
+++ b/src/detx.jl
@@ -1,12 +1,12 @@
 export detx
 
 """
-`detx(A::Matrix{T})` is an exact determinant of the matrix.
+`detx(A::AbstractMatrix{T})` is an exact determinant of the matrix.
 Here `T` can be any kind of integer, rational, `Mod`, or `GF2`.
 
 I hope to expand this to `Polynomial`s.
 """
-function detx(A::AbstractArray{T,2}) where T<:IntegerX
+function detx(A::AbstractMatrix{T}) where T<:IntegerX
     # @info "Using IntegerX detx{$T}"
     try
         return T(det(A//1))
@@ -16,7 +16,7 @@ function detx(A::AbstractArray{T,2}) where T<:IntegerX
     end
 end
 
-function detx(A::AbstractArray{T,2}) where T<:RationalX
+function detx(A::AbstractMatrix{T}) where T<:RationalX
     # @info "Using RationalX detx{$T}"
     try
         return det(A)
@@ -25,7 +25,7 @@ function detx(A::AbstractArray{T,2}) where T<:RationalX
     end
 end
 
-function detx(A::AbstractArray{T,2}) where T
+function detx(A::AbstractMatrix{T}) where T
     # @info "Using detx! on matrix of type $T"
     r,c = size(A)
     B = Matrix{Any}(undef,r,c)
@@ -42,7 +42,7 @@ end
 # detx! is the work behind det when we can't use Julia's det.
 # it can modify the matrix so this is not exposed to the general public.
 
-function detx!(A::AbstractArray{T,2}) where T
+function detx!(A::AbstractMatrix{T}) where T
     r,c = size(A)
     @assert r==c "Matrix must be square"
 

--- a/src/invx.jl
+++ b/src/invx.jl
@@ -5,7 +5,7 @@ export invx
 """
 `invx(A)` for a matrix `A` gives an exact matrix inverse.
 """
-function invx(A::AbstractArray{T,2}) where T
+function invx(A::AbstractMatrix{T}) where T
     r,c = size(A)
     @assert r==c "Matrix must be square"
 
@@ -22,7 +22,7 @@ function invx(A::AbstractArray{T,2}) where T
     if all(d.==1)
         return X[:,r+1:end]
     end
-    @error "Matrix is not intertible"
+    @error "Matrix is not invertible"
 end
 
 

--- a/src/nullspacex.jl
+++ b/src/nullspacex.jl
@@ -3,7 +3,7 @@ export nullspacex
 """
 `nullspacex(A)` returns an exact basis for the matrix `A`
 """
-function nullspacex(A::Matrix{T}) where T
+function nullspacex(A::AbstractMatrix{T}) where T
     r,c = size(A)
     B = rrefx(A)
 
@@ -37,6 +37,6 @@ function nullspacex(A::Matrix{T}) where T
 end
 
 
-function nullspacex(A::Matrix{T}) where T<: IntegerX
+function nullspacex(A::AbstractMatrix{T}) where T<: IntegerX
     return nullspacex(big.(A)//1)
 end

--- a/src/rankx.jl
+++ b/src/rankx.jl
@@ -3,7 +3,7 @@ export rankx
 """
 `rankx(A)` computes the rank of the exact matrix `A`
 """
-function rankx(A::AbstractArray{T,2})::Int where T
+function rankx(A::AbstractMatrix{T})::Int where T
     r,c = size(A)
 
     AA = A//1
@@ -28,7 +28,7 @@ end
 """
 `nullspacex(A)` returns an exact basis for the matrix `A`
 """
-function nullspacex(A::AbstractArray{T,2}) where T
+function nullspacex(A::AbstractMatrix{T}) where T
     r,c = size(A)
     B = rrefx(A)
 

--- a/src/row_ops.jl
+++ b/src/row_ops.jl
@@ -6,7 +6,7 @@ export row_swap!, row_scale!, row_add_mult!
 """
 `row_swap!(A,i,j)` swaps rows `i` and `j` in the matrix `A`.
 """
-function row_swap!(A::AbstractArray{T,2}, i::Int, j::Int) where T
+function row_swap!(A::AbstractMatrix{T}, i::Int, j::Int) where T
     r,c = size(A)
     @assert (1 <= i <= r) && (1 <= j <= r) "Row index out of bounds"
     if i==j
@@ -28,7 +28,7 @@ end
 `row_scale!(A,i,s)` multiplies all entries in row `i`
 of `A` by `s`.
 """
-function row_scale!(A::AbstractArray{T,2}, i::Int, s) where T
+function row_scale!(A::AbstractMatrix{T}, i::Int, s) where T
     r,c = size(A)
     @assert 1 <= i <= r "Row index out of bounds"
 
@@ -42,7 +42,7 @@ end
 `row_add_mult!(A,i,s,j)` adds `s` times row `i` to row `j`
 in the matrix `A`.
 """
-function row_add_mult!(A::AbstractArray{T,2},i::Int, s, j::Int) where T
+function row_add_mult!(A::AbstractMatrix{T},i::Int, s, j::Int) where T
     r,c = size(A)
     @assert (1 <= i <= r) && (1 <= j <= r) "Row index out of bounds"
 

--- a/src/rrefx.jl
+++ b/src/rrefx.jl
@@ -1,18 +1,18 @@
 export rrefx
 
-function rrefx(A::Matrix{T}) where T<: IntegerX
+function rrefx(A::AbstractMatrix{T}) where T<: IntegerX
     AA = big.(A//1)
     return rrefx(AA)
 end
 
-function rrefx(A::AbstractArray{T,2}) where T
+function rrefx(A::AbstractMatrix{T}) where T
     AA = copy(A)
     rrefx!(AA)
     return AA
 end
 
 
-function _pivot!(A::AbstractArray{T,2}, i::Int, j::Int) where T
+function _pivot!(A::AbstractMatrix{T}, i::Int, j::Int) where T
     r,c = size(A)
     s = A[i,j]
     row_scale!(A,i,invx(s))
@@ -27,7 +27,7 @@ end
 
 
 
-function rrefx!(A::AbstractArray{T,2}) where T
+function rrefx!(A::AbstractMatrix{T}) where T
     rn,nc = size(A)
 
     r = 1


### PR DESCRIPTION
`AbstractMatrix` is a more readable way to say `AbstractArray{T,2}`. If `AbstractMatrix` is used instead of `Matrix`, the methods will work with any custom matrix types by default.