### PR TITLE
Restrict `Mods.jl` to version 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearAlgebraX"
 uuid = "9b3f67b0-2d00-526e-9884-9e4938f8fb88"
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -10,7 +10,7 @@ Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 SimplePolynomials = "cc47b68c-3164-5771-a705-2bc0097375a0"
 
 [compat]
-Mods = "1, 2"
+Mods = "1"
 Permutations = "0.4"
 Primes = "0.5"
 SimplePolynomials = "0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.1, 0.2"


### PR DESCRIPTION
Hi @scheinerman. When starting the newest version of `Makie.jl`, it shows the following errors:
```
┌ CairoMakie [13f3f980-e62b-5c42-98c6-ff1f3baf88f0]
│  ┌ Warning: This version of Mods is still under development. Don't upgrade to version 2.0.x yet. I'm working on it.
│  └ @ Mods ~/.julia/packages/Mods/tdfSY/src/Mods.jl:5
└
┌ SimpleGraphs [55797a34-41de-5266-9ec1-32ac4eb504d3]
│  ┌ Warning: This version of Mods is still under development. Don't upgrade to version 2.0.x yet. I'm working on it.
│  └ @ Mods ~/.julia/packages/Mods/tdfSY/src/Mods.jl:5
└
┌ SimplePolynomials [cc47b68c-3164-5771-a705-2bc0097375a0]
│  ┌ Warning: This version of Mods is still under development. Don't upgrade to version 2.0.x yet. I'm working on it.
│  └ @ Mods ~/.julia/packages/Mods/tdfSY/src/Mods.jl:5
└
┌ LinearAlgebraX [9b3f67b0-2d00-526e-9884-9e4938f8fb88]
│  ┌ Warning: This version of Mods is still under development. Don't upgrade to version 2.0.x yet. I'm working on it.
│  └ @ Mods ~/.julia/packages/Mods/tdfSY/src/Mods.jl:5
└
┌ DelaunayTriangulation [927a84f5-c5f4-47a5-9785-b46e178433df]
│  ┌ Warning: This version of Mods is still under development. Don't upgrade to version 2.0.x yet. I'm working on it.
│  └ @ Mods ~/.julia/packages/Mods/tdfSY/src/Mods.jl:5
└
┌ Makie [ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a]
│  ┌ Warning: This version of Mods is still under development. Don't upgrade to version 2.0.x yet. I'm working on it.
│  └ @ Mods ~/.julia/packages/Mods/tdfSY/src/Mods.jl:5
└
```
Issues are already being opened such as https://github.com/MakieOrg/Makie.jl/issues/3441.

This pull request should fix it. By releasing a `LinearAlgebraX.jl` patch release (so that everyone will automatically update) and in this release restricting `Mods.jl` to version 1.

Thanks by the way for making these packages. It seems that they are vitally important for Julia 🙂 